### PR TITLE
feat: add choices for confidence levels.

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,18 +1,19 @@
 import pydantic
-from .core import PullActionConfiguration, AuthActionConfiguration
+from .core import PullActionConfiguration, AuthActionConfiguration, ExecutableActionMixin
 from .gfwclient import IntegratedAlertsConfidenceEnum, NasaViirsFireAlertConfidenceEnum
 
-class AuthenticateConfig(AuthActionConfiguration):
+class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
     email: str
-    password: str
-
+    password: pydantic.SecretStr = pydantic.Field(..., format="password", 
+                                                  title="Password",
+                                                  description="Password for the Global Forest Watch account.")
 
 class PullEventsConfig(PullActionConfiguration):
 
     gfw_share_link_url: pydantic.HttpUrl = pydantic.Field(
         ...,
-        title="GFW share link URL",
-        description="AOI URL link, extracted from GFW dashboard site."
+        title="Global Forest Watch AOI Share Link",
+        description="AOI share link from your MyGFW dashboard."
     )
     include_fire_alerts: bool = pydantic.Field(
         True,

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,6 +1,6 @@
 import pydantic
 from .core import PullActionConfiguration, AuthActionConfiguration
-
+from .gfwclient import IntegratedAlertsConfidenceEnum, NasaViirsFireAlertConfidenceEnum
 
 class AuthenticateConfig(AuthActionConfiguration):
     email: str
@@ -19,11 +19,25 @@ class PullEventsConfig(PullActionConfiguration):
         title="Include fire alerts",
         description="Fetch fire alerts from Global Forest Watch and include them in this connection."
     )
+
+    fire_alerts_lowest_confidence: NasaViirsFireAlertConfidenceEnum = pydantic.Field(
+        NasaViirsFireAlertConfidenceEnum.high,
+        title="Fire alerts lowest confidence",
+        description="Lowest confidence level to include in the connection."
+    )
+
     include_integrated_alerts: bool = pydantic.Field(
         True,
         title="Include integrated deforestation alerts",
         description="Fetch integrated deforestation alerts from Global Forest Watch and include them in the connection."
     )
+
+    integrated_alerts_lowest_confidence: IntegratedAlertsConfidenceEnum = pydantic.Field(
+        IntegratedAlertsConfidenceEnum.highest,
+        title="Integrated deforestation alerts lowest confidence",
+        description="Lowest confidence level to include in the connection."
+    )
+
     fire_lookback_days: int = pydantic.Field(
         10,
         le=10,

--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -11,6 +11,9 @@ class PullActionConfiguration(ActionConfiguration):
     pass
 
 
+class ExecutableActionMixin:
+    pass
+
 class PushActionConfiguration(ActionConfiguration):
     pass
 

--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -6,7 +6,7 @@ import pydantic
 import random
 import re
 import backoff
-import uuid
+from enum import Enum
 
 import httpx
 from datetime import datetime, timedelta, timezone
@@ -273,6 +273,18 @@ class DatasetFields(pydantic.BaseModel):
     data: Optional[List[DatasetField]] = None
     status: Optional[str] = None
 
+class IntegratedAlertsConfidenceEnum(str, Enum):
+    high = 'high'
+    highest = 'highest'
+
+IntegratedAlertsConfidenceEnumOrder = [IntegratedAlertsConfidenceEnum.high, IntegratedAlertsConfidenceEnum.highest]
+
+class NasaViirsFireAlertConfidenceEnum(str, Enum):
+    nominal = 'n'
+    low = 'l'
+    high = 'h'
+
+NasaViirsFireAlertConfidenceEnumOrder = [NasaViirsFireAlertConfidenceEnum.low, NasaViirsFireAlertConfidenceEnum.nominal, NasaViirsFireAlertConfidenceEnum.high]
 
 def giveup_handler(details):
     d1, d2 = details['kwargs']['daterange']
@@ -285,6 +297,13 @@ def backoff_hdlr(details):
            "calling function {target} with args {args} and kwargs "
            "{kwargs}".format(**details))
     
+
+# Custom backoff strategy starting at 5, incrementing by 10, and capping at 45
+def custom_backoff():
+    delay = 5
+    while delay <= 45:
+        yield delay
+        delay += 10
 
 DEFAULT_REQUEST_TIMEOUT = httpx.Timeout(60.0, connect=3.1)
 class DataAPI:
@@ -477,8 +496,8 @@ class DataAPI:
             if val.status == 'success':
                 return val.data
 
-    @backoff.on_exception(backoff.constant, (httpx.TimeoutException, httpx.HTTPStatusError),
-                          interval=5, max_tries=3, 
+    @backoff.on_exception(custom_backoff, (httpx.TimeoutException, httpx.HTTPStatusError),
+                          max_tries=5, 
                           on_giveup=giveup_handler, raise_on_giveup=False,
                           on_backoff=backoff_hdlr)
     async def get_alerts(
@@ -524,7 +543,7 @@ class DataAPI:
                 if httpx.codes.is_success(response.status_code):
                     data = response.json()
                     data_len = len(data.get("data"))
-                    logger.info(f"Extracted {data_len} alerts from dataset {dataset} for period {lower_date} - {upper_date}.")
+                    logger.info(f"Extracted {data_len} alerts from dataset {dataset}, geostore_id: {geostore_id} for period {lower_date} - {upper_date}.")
                     return data.get("data", [])
                 else:
                     logger.error(
@@ -536,7 +555,18 @@ class DataAPI:
         return await fn()
 
     @backoff.on_exception(backoff.expo, (httpx.TimeoutException, httpx.HTTPStatusError), max_tries=3, on_backoff=backoff_hdlr)
-    async def get_gfw_integrated_alerts(self, *, geostore_id: str,date_range: Tuple[datetime, datetime], semaphore: asyncio.Semaphore = None):
+    async def get_gfw_integrated_alerts(self, *, geostore_id: str,date_range: Tuple[datetime, datetime],
+                                        lowest_confidence: IntegratedAlertsConfidenceEnum = IntegratedAlertsConfidenceEnum.highest,
+                                          semaphore: asyncio.Semaphore = None):
+
+        try:
+            index = IntegratedAlertsConfidenceEnumOrder.index(lowest_confidence)
+            confidence_values = IntegratedAlertsConfidenceEnumOrder[index:] 
+            confidence_values = ' OR '.join(f'gfw_integrated_alerts__confidence = \'{value}\'' for value in confidence_values)
+            extra_where = f"({confidence_values})"
+        except ValueError:
+            extra_where = ''
+            logger.warning(f"Invalid confidence value: {lowest_confidence}. Using all confidence values.")
 
         async with semaphore:
             fields = {"gfw_integrated_alerts__date", "gfw_integrated_alerts__confidence"}
@@ -545,14 +575,25 @@ class DataAPI:
                 date_field="gfw_integrated_alerts__date",
                 daterange=date_range,
                 fields=fields,
-                extra_where="(gfw_integrated_alerts__confidence = 'highest')",
+                extra_where=extra_where,
                 geostore_id=geostore_id
             )
         
         return [IntegratedAlert.parse_obj(alert) for alert in alerts] if alerts else []
         
     @backoff.on_exception(backoff.expo, (httpx.TimeoutException, httpx.HTTPStatusError), max_tries=3, on_backoff=backoff_hdlr)
-    async def get_nasa_viirs_fire_alerts(self, *, geostore_id: str,date_range: Tuple[datetime, datetime], semaphore: asyncio.Semaphore = None):
+    async def get_nasa_viirs_fire_alerts(self, *, geostore_id: str,date_range: Tuple[datetime, datetime],
+                                         lowest_confidence: NasaViirsFireAlertConfidenceEnum = NasaViirsFireAlertConfidenceEnum.high,
+                                         semaphore: asyncio.Semaphore = None):
+
+        try:
+            index = NasaViirsFireAlertConfidenceEnumOrder.index(lowest_confidence)
+            confidence_values = NasaViirsFireAlertConfidenceEnumOrder[index:] 
+            confidence_values = ' OR '.join(f'confidence__cat = \'{value}\'' for value in confidence_values)
+            extra_where = f"({confidence_values})"
+        except ValueError:
+            extra_where = ''
+            logger.warning(f"Invalid confidence value: {lowest_confidence}. Using all confidence values.")
 
         async with semaphore:
             fields = {"confidence__cat", "alert__date"}
@@ -561,7 +602,7 @@ class DataAPI:
                 date_field="alert__date",
                 daterange=date_range,
                 fields=fields,
-                extra_where="(confidence__cat = 'h')",
+                extra_where=extra_where,
                 geostore_id=geostore_id
             )
         

--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -280,9 +280,9 @@ class IntegratedAlertsConfidenceEnum(str, Enum):
 IntegratedAlertsConfidenceEnumOrder = [IntegratedAlertsConfidenceEnum.high, IntegratedAlertsConfidenceEnum.highest]
 
 class NasaViirsFireAlertConfidenceEnum(str, Enum):
-    nominal = 'n'
-    low = 'l'
-    high = 'h'
+    nominal = 'nominal'
+    low = 'low'
+    high = 'high'
 
 NasaViirsFireAlertConfidenceEnumOrder = [NasaViirsFireAlertConfidenceEnum.low, NasaViirsFireAlertConfidenceEnum.nominal, NasaViirsFireAlertConfidenceEnum.high]
 
@@ -589,6 +589,7 @@ class DataAPI:
         try:
             index = NasaViirsFireAlertConfidenceEnumOrder.index(lowest_confidence)
             confidence_values = NasaViirsFireAlertConfidenceEnumOrder[index:] 
+            confidence_values = [str(value).lower()[:1] for value in confidence_values]
             confidence_values = ' OR '.join(f'confidence__cat = \'{value}\'' for value in confidence_values)
             extra_where = f"({confidence_values})"
         except ValueError:

--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -178,6 +178,9 @@ class NasaViirsFireAlert(pydantic.BaseModel):
     confidence: str = pydantic.Field(..., alias="confidence__cat")
 
     alert_date: datetime = pydantic.Field(..., alias="alert__date")
+    frp: float = pydantic.Field(0.0, alias="frp__MW")
+    bright_ti4: float = pydantic.Field(0.0, alias="bright_ti4__K")
+    bright_ti5: float = pydantic.Field(0.0, alias="bright_ti5__K")
 
     @pydantic.validator("alert_date", pre=True)
     def sanitized_date(cls, val) -> datetime:
@@ -597,7 +600,7 @@ class DataAPI:
             logger.warning(f"Invalid confidence value: {lowest_confidence}. Using all confidence values.")
 
         async with semaphore:
-            fields = {"confidence__cat", "alert__date"}
+            fields = {"confidence__cat", "alert__date", "frp__MW", "bright_ti4__K", "bright_ti5__K"}
             alerts = await self.get_alerts(
                 dataset="nasa_viirs_fire_alerts",
                 date_field="alert__date",

--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -335,7 +335,7 @@ class DataAPI:
                     dapitoken = DataAPIToken.parse_obj(response.json()["data"])
                     return dapitoken
 
-            raise DataAPIAuthException("Failed to get an access token for username {self._username}.")
+            raise DataAPIAuthException(f"Failed to get an access token for username {self._username}.")
 
     async def auth_generator(self):
         """

--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -497,7 +497,7 @@ class DataAPI:
                 return val.data
 
     @backoff.on_exception(custom_backoff, (httpx.TimeoutException, httpx.HTTPStatusError),
-                          max_tries=5, 
+                          max_tries=3, 
                           on_giveup=giveup_handler, raise_on_giveup=False,
                           on_backoff=backoff_hdlr)
     async def get_alerts(

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -6,7 +6,7 @@ import app.settings
 
 from app.actions import utils
 from app.actions.gfwclient import DataAPI, Geostore, DatasetStatus, \
-    AOIData, DATASET_GFW_INTEGRATED_ALERTS, DATASET_NASA_VIIRS_FIRE_ALERTS
+    AOIData, DATASET_GFW_INTEGRATED_ALERTS, DATASET_NASA_VIIRS_FIRE_ALERTS, DataAPIAuthException
 from shapely.geometry import GeometryCollection, shape, mapping
 from datetime import timezone, timedelta, datetime
 
@@ -84,13 +84,8 @@ async def action_auth(integration, action_config: AuthenticateConfig):
     try:
         dataapi = DataAPI(username=action_config.email, password=action_config.password.get_secret_value())
         token = await dataapi.get_access_token()
-    except Exception as e:
-        message = f"auth action returned error."
-        logger.exception(message, extra={
-            "integration_id": str(integration.id),
-            "attention_needed": True
-        })
-        raise e
+    except DataAPIAuthException as e:
+        return {"valid_credentials": False, "message": f"Failed to authenticate with Global Forest Watch Data API: {e}"}
     else:
         logger.info(f"Authenticated with success. token: {token}")
     

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -82,7 +82,7 @@ def transform_integrated_alert(alert):
 async def action_auth(integration, action_config: AuthenticateConfig):
     logger.info(f"Executing auth action with integration {integration} and action_config {action_config}...")
     try:
-        dataapi = DataAPI(username=action_config.email, password=action_config.password.value)
+        dataapi = DataAPI(username=action_config.email, password=action_config.password.get_secret_value())
         token = await dataapi.get_access_token()
     except Exception as e:
         message = f"auth action returned error."
@@ -123,7 +123,7 @@ async def action_pull_events(integration:Integration, action_config: PullEventsC
     auth_config = get_auth_config(integration)
 
     # Get AOI data first.
-    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.value)
+    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.get_secret_value())
 
     aoi_id = await dataapi.aoi_from_url(action_config.gfw_share_link_url)
     aoi_data = await dataapi.get_aoi(aoi_id=aoi_id)
@@ -199,7 +199,7 @@ async def get_integrated_alerts(integration:Integration, action_config: PullEven
     if not action_config.include_integrated_alerts:
         return {'dataset': DATASET_GFW_INTEGRATED_ALERTS, "message": 'Not included in action config.'}
 
-    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.value)
+    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.get_secret_value())
 
     dataset_metadata = await dataapi.get_dataset_metadata(DATASET_GFW_INTEGRATED_ALERTS)
     dataset_status = await state_manager.get_state(
@@ -279,7 +279,7 @@ async def get_nasa_viirs_fire_alerts(integration:Integration, action_config: Pul
     if not action_config.include_fire_alerts:
         return {'dataset': DATASET_NASA_VIIRS_FIRE_ALERTS, "message": 'Not included in action config.'}
 
-    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.value)
+    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.get_secret_value())
 
     dataset_metadata = await dataapi.get_dataset_metadata(DATASET_NASA_VIIRS_FIRE_ALERTS)
     dataset_status = await state_manager.get_state(

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -241,7 +241,8 @@ async def get_integrated_alerts(integration:Integration, action_config: PullEven
     geostore_ids = await state_manager.get_geostore_ids(aoi_data.id)
 
     # Generate tasks for each geostore_id and 48 hour partition.
-    tasks = [dataapi.get_gfw_integrated_alerts(geostore_id=geostore_id.decode('utf8'), date_range=(lower, upper), semaphore=sema)
+    tasks = [dataapi.get_gfw_integrated_alerts(geostore_id=geostore_id.decode('utf8'), date_range=(lower, upper),
+                                               lowest_confidence=action_config.integrated_alerts_lowest_confidence, semaphore=sema)
               for geostore_id in geostore_ids 
               for lower, upper in generate_date_pairs(start_date, end_date)]
     
@@ -318,7 +319,8 @@ async def get_nasa_viirs_fire_alerts(integration:Integration, action_config: Pul
     start_date = end_date - timedelta(days=action_config.integrated_alerts_lookback_days)
 
     # Generate tasks for each geostore_id and 48 hour partition.
-    tasks = [dataapi.get_nasa_viirs_fire_alerts(geostore_id=geostore_id.decode('utf8'), date_range=(lower, upper), semaphore=sema)
+    tasks = [dataapi.get_nasa_viirs_fire_alerts(geostore_id=geostore_id.decode('utf8'), date_range=(lower, upper),
+                                                lowest_confidence=action_config.fire_alerts_lowest_confidence, semaphore=sema)
               for geostore_id in geostore_ids 
               for lower, upper in generate_date_pairs(start_date, end_date)]
     for t in asyncio.as_completed(tasks):

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -82,7 +82,7 @@ def transform_integrated_alert(alert):
 async def action_auth(integration, action_config: AuthenticateConfig):
     logger.info(f"Executing auth action with integration {integration} and action_config {action_config}...")
     try:
-        dataapi = DataAPI(username=action_config.email, password=action_config.password)
+        dataapi = DataAPI(username=action_config.email, password=action_config.password.value)
         token = await dataapi.get_access_token()
     except Exception as e:
         message = f"auth action returned error."
@@ -123,7 +123,7 @@ async def action_pull_events(integration:Integration, action_config: PullEventsC
     auth_config = get_auth_config(integration)
 
     # Get AOI data first.
-    dataapi = DataAPI(username=auth_config.email, password=auth_config.password)
+    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.value)
 
     aoi_id = await dataapi.aoi_from_url(action_config.gfw_share_link_url)
     aoi_data = await dataapi.get_aoi(aoi_id=aoi_id)
@@ -199,7 +199,7 @@ async def get_integrated_alerts(integration:Integration, action_config: PullEven
     if not action_config.include_integrated_alerts:
         return {'dataset': DATASET_GFW_INTEGRATED_ALERTS, "message": 'Not included in action config.'}
 
-    dataapi = DataAPI(username=auth_config.email, password=auth_config.password)
+    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.value)
 
     dataset_metadata = await dataapi.get_dataset_metadata(DATASET_GFW_INTEGRATED_ALERTS)
     dataset_status = await state_manager.get_state(
@@ -279,7 +279,7 @@ async def get_nasa_viirs_fire_alerts(integration:Integration, action_config: Pul
     if not action_config.include_fire_alerts:
         return {'dataset': DATASET_NASA_VIIRS_FIRE_ALERTS, "message": 'Not included in action config.'}
 
-    dataapi = DataAPI(username=auth_config.email, password=auth_config.password)
+    dataapi = DataAPI(username=auth_config.email, password=auth_config.password.value)
 
     dataset_metadata = await dataapi.get_dataset_metadata(DATASET_NASA_VIIRS_FIRE_ALERTS)
     dataset_status = await state_manager.get_state(

--- a/app/actions/utils.py
+++ b/app/actions/utils.py
@@ -11,7 +11,7 @@ def generate_rectangle_cells(xmin, ymin, xmax, ymax, interval=0.3):
         xmin += interval
 
 
-def generate_geometry_fragments(geometry_collection, interval=1):
+def generate_geometry_fragments(geometry_collection, interval=0.5):
 
     geometry_collection = geometry_collection.simplify(tolerance=0.0005, preserve_topology=True)
 

--- a/app/services/self_registration.py
+++ b/app/services/self_registration.py
@@ -5,7 +5,7 @@ import logging
 import stamina
 import httpx
 
-from app.actions import action_handlers, AuthActionConfiguration, PullActionConfiguration, PushActionConfiguration
+from app.actions import action_handlers, AuthActionConfiguration, PullActionConfiguration, PushActionConfiguration, ExecutableActionMixin
 from app.settings import INTEGRATION_TYPE_SLUG, INTEGRATION_SERVICE_URL
 from .core import ActionTypeEnum
 from app.webhooks.core import get_webhook_handler, GenericJsonTransformConfig
@@ -46,6 +46,10 @@ async def register_integration_in_gundi(gundi_client, type_slug=None, service_ur
             action_type = ActionTypeEnum.PUSH_DATA.value
         else:
             action_type = ActionTypeEnum.GENERIC.value
+
+        if issubclass(config_model, ExecutableActionMixin):
+            action_schema['is_executable'] = True
+            
         actions.append(
             {
                 "type": action_type,


### PR DESCRIPTION
For Global Forest Watch, we have options for selecting events based on confidence levels.

For fire alerts we have (high, nominal, low)
For integrated alerts (aka tree-loss) we have (high, highest)

The desired outcome is to show these choices in our UI, and default them to the highest confidence levels.

Ticket: https://allenai.atlassian.net/browse/GUNDI-3589