### PR TITLE
Hotfix validate geometry partitions

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -153,12 +153,13 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         )
         for partition in utils.generate_geometry_fragments(geometry_collection=geometry_collection):
             if partition == "error":
+                msg = f"Error while generating geometry fragments for Geometry collection {geometry_collection}. AOI {aoi_data.id}."
                 await log_activity(
                     integration_id=integration.id,
                     action_id="pull_events",
                     level=LogLevel.WARNING,
-                    title=f"Geometry collection has no bounds for AOI {aoi_data.id}.",
-                    data={"message": f"Geometry collection has no bounds for AOI {aoi_data.id}."}
+                    title=msg,
+                    data={"message": msg}
                 )
                 break
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -11,7 +11,7 @@ from shapely.geometry import GeometryCollection, shape, mapping
 from datetime import timezone, timedelta, datetime
 
 from app.actions.configurations import AuthenticateConfig, PullEventsConfig
-from app.services.activity_logger import activity_logger, log_activity
+from app.services.activity_logger import activity_logger, log_action_activity
 from app.services.gundi import send_events_to_gundi
 from app.services.state import IntegrationStateManager
 from app.services.errors import ConfigurationNotFound
@@ -158,7 +158,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
                 except AttributeError:
                     msg = f"Error while creating Geostore for Geometry Collection (invalid partition)."
                     logger.exception(msg)
-                    await log_activity(
+                    await log_action_activity(
                         integration_id=integration.id,
                         action_id="pull_events",
                         level=LogLevel.WARNING,
@@ -170,7 +170,7 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
         except ValueError:
             msg = f"Error while generating geometry fragments for Geometry Collection."
             logger.exception(msg)
-            await log_activity(
+            await log_action_activity(
                 integration_id=integration.id,
                 action_id="pull_events",
                 level=LogLevel.WARNING,

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -151,21 +151,25 @@ async def action_pull_events(integration: Integration, action_config: PullEvents
                 for feature in geostore.attributes.geojson["features"]
             ]
         )
-        for partition in utils.generate_geometry_fragments(geometry_collection=geometry_collection):
-            if partition == "error":
-                msg = f"Error while generating geometry fragments for Geometry collection {geometry_collection}. AOI {aoi_data.id}."
-                await log_activity(
-                    integration_id=integration.id,
-                    action_id="pull_events",
-                    level=LogLevel.WARNING,
-                    title=msg,
-                    data={"message": msg}
-                )
-                break
+        try:
+            for partition in utils.generate_geometry_fragments(geometry_collection=geometry_collection):
+                geostore = await dataapi.create_geostore(geometry=mapping(partition))
 
-            geostore = await dataapi.create_geostore(geometry=mapping(partition))
+                await state_manager.add_geostore_id(aoi_data.id, geostore.gfw_geostore_id)
 
-            await state_manager.add_geostore_id(aoi_data.id, geostore.gfw_geostore_id)
+        except ValueError:
+            msg = f"Error while generating geometry fragments for Geometry Collection."
+            logger.exception(msg)
+            await log_activity(
+                integration_id=integration.id,
+                action_id="pull_events",
+                level=LogLevel.WARNING,
+                title=msg,
+                data={"aoi_data": aoi_data.dict(), "geometry_collection": geometry_collection.wkt}
+            )
+
+
+
 
         await state_manager.set_geostores_id_ttl(aoi_data.id, 86400*7)
 

--- a/app/actions/utils.py
+++ b/app/actions/utils.py
@@ -29,7 +29,8 @@ def generate_geometry_fragments(geometry_collection, interval=0.5):
     # Check if envelope has valid bounds
     if not envelope.bounds:
         logger.warning(f"Geometry collection has no bounds: {geometry_collection}")
-        yield "error"
+        raise ValueError("The geometry collection does not have valid envelope bounds.")
+
 
     for xmin, ymin, xmax, ymax in generate_rectangle_cells(
         envelope.bounds[0],

--- a/app/actions/utils.py
+++ b/app/actions/utils.py
@@ -1,4 +1,8 @@
+import logging
 import shapely.geometry
+
+
+logger = logging.getLogger(__name__)
 
 
 def generate_rectangle_cells(xmin, ymin, xmax, ymax, interval=0.3):
@@ -21,6 +25,12 @@ def generate_geometry_fragments(geometry_collection, interval=0.5):
         geometry_collection = geometry_collection.buffer(0)
 
     envelope = geometry_collection.envelope
+
+    # Check if envelope has valid bounds
+    if not envelope.bounds:
+        logger.warning(f"Geometry collection has no bounds: {geometry_collection}")
+        yield "error"
+
     for xmin, ymin, xmax, ymax in generate_rectangle_cells(
         envelope.bounds[0],
         envelope.bounds[1],

--- a/app/actions/utils.py
+++ b/app/actions/utils.py
@@ -28,7 +28,7 @@ def generate_geometry_fragments(geometry_collection, interval=0.5):
 
     # Check if envelope has valid bounds
     if not envelope.bounds:
-        logger.warning(f"Geometry collection has no bounds: {geometry_collection}")
+        logger.error(f"Geometry collection has no bounds: {geometry_collection}")
         raise ValueError("The geometry collection does not have valid envelope bounds.")
 
 


### PR DESCRIPTION
### Relevant Link:

https://allenai.atlassian.net/browse/GUNDI-4039


This pull request includes several changes to improve error handling and logging in the `app/actions` module.

The most important changes include adding logging for geometry collection errors, removing unused code, and importing necessary modules.

Improvements to error handling and logging:

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L14-R19): Added logging for cases where the geometry collection has no bounds during the `action_pull_events` function. This includes importing `log_activity` and `LogLevel` for logging purposes. [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L14-R19) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R155-R163)

Code cleanup:

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L144-L146): Removed unused code that fetched AOI data in the `action_pull_events` function.

Imports and logging setup:

* [`app/actions/utils.py`](diffhunk://#diff-e6be7d6e5f6c22c340ab8dab6c260a051213c9bec95f969eb4659680afffa375R1-R7): Added the `logging` module and set up a logger to log warnings when the geometry collection has no bounds in the `generate_geometry_fragments` function. [[1]](diffhunk://#diff-e6be7d6e5f6c22c340ab8dab6c260a051213c9bec95f969eb4659680afffa375R1-R7) [[2]](diffhunk://#diff-e6be7d6e5f6c22c340ab8dab6c260a051213c9bec95f969eb4659680afffa375R28-R33)