### PR TITLE
Sync 20250219

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-slim AS baseimage
 
 # This command is for webhooks support
 RUN apt-get update && apt-get install -y autoconf automake libtool make python3-dev
@@ -9,4 +9,18 @@ COPY requirements.txt .
 RUN pip install --upgrade pip && pip install -r /code/requirements.txt
 COPY ./app app/
 
+FROM baseimage AS devimage
+
+COPY requirements-dev.in .
+RUN pip install -r /code/requirements-dev.in
+
+# Install debugpy for debugging
+RUN pip install debugpy
+
+# Expose debugpy port too
+EXPOSE 8080 5678
+CMD ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--reload"]
+
+FROM baseimage AS prodimage
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+

--- a/local/.env.local.example
+++ b/local/.env.local.example
@@ -1,0 +1,25 @@
+# Create a copy of this file and name is .env.local
+
+
+# Edit this to have a secret from the stage environment (Ask the Gundi Team)
+KEYCLOAK_CLIENT_SECRET="a-secret-from-gundi-stage"
+
+LOG_LEVEL="DEBUG"
+CDIP_ADMIN_ENDPOINT="https://api.stage.gundiservice.org"
+GUNDI_API_BASE_URL="https://api.stage.gundiservice.org"
+KEYCLOAK_AUDIENCE="cdip-admin-portal"
+KEYCLOAK_CLIENT_ID="cdip-integrations"
+KEYCLOAK_ISSUER="https://cdip-auth.pamdas.org/auth/realms/cdip-dev"
+SENSORS_API_BASE_URL="https://sensors.api.stage.gundiservice.org"
+REDIS_HOST="redis"
+REDIS_PORT="6379"
+
+
+# These settings are for using a local pubsub emulator.
+# It's recommended to leave these as-is. If you change values in this section, 
+# you will likely have to change values in helper scripts too.
+INTEGRATION_EVENTS_TOPIC="integration-events"
+GCP_PROJECT_ID="local-project"
+PUBSUB_EMULATOR_HOST=pubsub_emulator:8085
+PUBSUB_PROJECT_ID=local-project
+INTEGRATION_COMMANDS_TOPIC="local-actions-topic"

--- a/local/.gitignore
+++ b/local/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/local/LOCAL_DEVELOPMENT.md
+++ b/local/LOCAL_DEVELOPMENT.md
@@ -1,0 +1,38 @@
+# Running an Action Runner Locally
+
+You can run this Action Runner locally using Docker Compose. This will allow you to develop the code and debug it locally while still taking advantage of Gundi Core services.
+
+## Requirements
+
+- Python 3.10
+- Docker
+- Docker Compose
+
+## Steps
+
+Inside the `local` directory, do these things:
+
+**Set your Environment**
+
+Create a copy of `.env.local.example` and name it `.env.local`
+
+Edit the `.env.local` file and set the `KEYCLOAK_CLIENT_SECRET` to a secret from the stage environment (Ask the Gundi Team)
+
+**Build and Run**
+
+In a Terminal, run `docker compose up --build`
+
+> [!NOTE]
+>
+> The Be sure to compile a `requirements.txt` file before running the docker compose command, or you might miss some important dependencies.
+
+
+Once these steps are complete you can visit http://localhost:8080/docs to see your Action Runner's browsable API.
+
+## Notes
+
+- This example uses configuration from https://stage.gundiservice.org.
+
+
+
+

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,65 @@
+
+services:
+
+  redis:
+    image: redis:latest
+    container_name: redis_server
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 15s
+      timeout: 15s
+      retries: 10
+
+  pubsub_emulator:
+    image: google/cloud-sdk:latest
+    container_name: pubsub_emulator
+    entrypoint: ["gcloud", "beta", "emulators", "pubsub", "start", "--project=local-project", "--host-port=0.0.0.0:8085"]
+    environment:
+      PUBSUB_PROJECT_ID: local-project
+      PUBSUB_EMULATOR_HOST: pubsub_emulator:8085
+    ports:
+      - "8085:8085"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://0.0.0.0:8085/"]
+      interval: 15s
+      timeout: 15s
+      retries: 10
+
+  pubsub_topic_initializer:
+      image: curlimages/curl:latest
+      container_name: pubsub_topic_initializer
+      depends_on:
+        pubsub_emulator:
+          condition: service_healthy
+      entrypoint: ["sh", "-c"]
+      command: ["source /helpers/create_subscriptions.sh"]
+      volumes:
+        - ./helpers:/helpers
+  fastapi:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      target: devimage
+    container_name: fastapi_server
+    ports:
+      - "8080:8080"
+      - "5678:5678"
+    volumes:
+      - ../app:/code/app
+    env_file:
+      - path: ".env.local"
+        required: true
+    depends_on:
+      redis:
+        condition: service_healthy
+      pubsub_emulator:
+        condition: service_healthy
+      pubsub_topic_initializer:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://0.0.0.0:8080/"]
+      interval: 15s
+      timeout: 15s
+      retries: 10

--- a/local/helpers/create_subscriptions.sh
+++ b/local/helpers/create_subscriptions.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# This script is used as part of automating a local development environment, particlarly for testing
+# sub-actions in an Action Runner.
+
+# This first operation is meant to wait until the PubSub emulator is up and running.
+until curl -X PUT http://pubsub_emulator:8085/v1/projects/local-project/topics/integration-events; do sleep 2; done
+
+# This createst the `local-actions-topic` topic. It's where the action runner is going to publish sub-actions.
+curl -X PUT http://pubsub_emulator:8085/v1/projects/local-project/topics/local-actions-topic
+
+# ...and this is where the subscription is made, to push 'local-actions-topic' messages to the FastAPI server (the action runner service).
+curl http://pubsub_emulator:8085/v1/projects/local-project/subscriptions/local-actions-subscription \
+ --data '{"topic": "projects/local-project/topics/local-actions-topic", "pushConfig": {"pushEndpoint": "http://fastapi:8080/"}}' \
+  -X PUT -H 'content-type: application/json'


### PR DESCRIPTION
@vgarcia13 This is a merge for some recent code added in the template that allows for easily running the action runner locally (including with pubsub'ed sub-actions).

This pull request includes multiple changes to set up a local development environment using Docker and Docker Compose, as well as improvements to the project's documentation and configuration files. The most important changes include modifications to the `Dockerfile`, the addition of a `.env.local.example` file, updates to the `.gitignore` file, new documentation for local development, and a new Docker Compose configuration.

### Docker and Docker Compose setup:

* [`docker/Dockerfile`](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL1-R1): Split the base image into separate stages for development and production, added installation of development dependencies, and set up debugging capabilities. [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL1-R1) [[2]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR12-R26)
* [`local/docker-compose.yml`](diffhunk://#diff-1ae4c0545a7ce890cd85b33bd9b64e792c9399f90c03a0137a85f38f80e42606R1-R65): Added services for Redis, Pub/Sub emulator, and FastAPI with health checks and dependencies to facilitate local development.

### Configuration and environment setup:

* [`local/.env.local.example`](diffhunk://#diff-5f078bf90f96ce0a042654d1e4d3eacc4bf94433b346a42401b03e1b472739f4R1-R25): Added an example environment configuration file with necessary variables for local development.
* [`local/.gitignore`](diffhunk://#diff-fba71a4d6c6e88326486a20595d3d7bd2c30037b1135e4b189d41d283b6c735bR1): Updated to ignore the local environment configuration file.

### Documentation:

* [`local/LOCAL_DEVELOPMENT.md`](diffhunk://#diff-15f70eee4569e97cc836d85959bfae98d9ca3ae031aa15c250afcc3eb3f8f812R1-R38): Added documentation on how to run the Action Runner locally using Docker Compose, including environment setup and build instructions.

### Helper scripts:

* [`local/helpers/create_subscriptions.sh`](diffhunk://#diff-ca092655ae9e5158fe67a746b827212855062129723770e0e57f309ef3c3dc37R1-R15): Added a script to automate the creation of Pub/Sub topics and subscriptions for local development.