### PR TITLE
`partition_interval_size_in_degrees` UI params

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -87,24 +87,29 @@ class PullEventsConfig(PullActionConfiguration):
         description="Force fetch even if in a quiet period."
     )
 
-    partition_interval_size_in_degrees: float = pydantic.Field(
+    partition_interval_size_in_degrees: float = FieldWithUIOptions(
         1.0,
         title="Partition interval size in degrees",
         description="Size of the partition interval in degrees.",
-        max=1.0,
-        min=0.3
+        le=1.0,
+        ge=0.1,
+        multiple_of=0.01,
+        # ui_options=UIOptions(
+        #     widget="range",  # This will be rendered ad a range slider
+        # )
+        # TODO: Check the hardcoded step in the UI
     )
 
     ui_global_options: GlobalUISchemaOptions = GlobalUISchemaOptions(
         order=[
             "gfw_share_link_url",
+            "partition_interval_size_in_degrees",
             "include_fire_alerts",
             "fire_lookback_days",
             "fire_alerts_lowest_confidence",
             "include_integrated_alerts",
             "integrated_alerts_lookback_days",
             "integrated_alerts_lowest_confidence",
-            "partition_interval_size_in_degrees",
             "force_fetch"
         ],
     )


### PR DESCRIPTION
This pull request includes a change to the `PullEventsConfig` class in the `configurations.py` file to enhance the configuration options for the `partition_interval_size_in_degrees` field.

Configuration Enhancements:

* [`app/actions/configurations.py`](diffhunk://#diff-0c07ea434f0a65b6e42dfb436000af783a7bd80e905bbed3d9cb7f67b779d895L90-L107): Changed the type of `partition_interval_size_in_degrees` from `pydantic.Field` to `FieldWithUIOptions`, updated its constraints, and adjusted its position in the `order` list within `ui_global_options`.