### PR TITLE
Save datasets status only once per execution

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -342,7 +342,7 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
             integrated_dataset_metadata = None
 
     # Check if any of the datasets is valid to trigger sub-actions
-    if fire_dataset_metadata or integrated_dataset_metadata:
+    if any([fire_dataset_metadata, integrated_dataset_metadata]):
         for geostore_id in geostore_ids:
             for lower, upper in generate_date_pairs(start_date, end_date):
                 if fire_dataset_metadata:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -341,41 +341,43 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
             )
             integrated_dataset_metadata = None
 
-    for geostore_id in geostore_ids:
-        for lower, upper in generate_date_pairs(start_date, end_date):
-            if fire_dataset_metadata:
-                # Trigger "get_nasa_viirs_fire_alerts" sub-action
-                config = GetNasaVIIRSFireAlertsForGeostoreID(
-                    integration_id=str(integration.id),
-                    geostore_id=geostore_id.decode('utf8'),
-                    date_range=(lower, upper),
-                    lowest_confidence=action_config.pull_events_config.fire_alerts_lowest_confidence,
-                    dataset=fire_dataset_metadata
-                )
+    # Check if any of the datasets is valid to trigger sub-actions
+    if fire_dataset_metadata or integrated_dataset_metadata:
+        for geostore_id in geostore_ids:
+            for lower, upper in generate_date_pairs(start_date, end_date):
+                if fire_dataset_metadata:
+                    # Trigger "get_nasa_viirs_fire_alerts" sub-action
+                    config = GetNasaVIIRSFireAlertsForGeostoreID(
+                        integration_id=str(integration.id),
+                        geostore_id=geostore_id.decode('utf8'),
+                        date_range=(lower, upper),
+                        lowest_confidence=action_config.pull_events_config.fire_alerts_lowest_confidence,
+                        dataset=fire_dataset_metadata
+                    )
 
-                await trigger_action(
-                    integration.id,
-                    "get_nasa_viirs_fire_alerts_for_geostore_and_date_range",
-                    config=config
-                )
-                fire_alerts_actions_triggered += 1
+                    await trigger_action(
+                        integration.id,
+                        "get_nasa_viirs_fire_alerts_for_geostore_and_date_range",
+                        config=config
+                    )
+                    fire_alerts_actions_triggered += 1
 
-            if integrated_dataset_metadata:
-                # Trigger "get_gfw_integrated_alerts" sub-action
-                config = GetIntegratedAlertsForGeostoreID(
-                    integration_id=str(integration.id),
-                    geostore_id=geostore_id.decode('utf8'),
-                    date_range=(lower, upper),
-                    lowest_confidence=action_config.pull_events_config.integrated_alerts_lowest_confidence,
-                    dataset=integrated_dataset_metadata
-                )
+                if integrated_dataset_metadata:
+                    # Trigger "get_gfw_integrated_alerts" sub-action
+                    config = GetIntegratedAlertsForGeostoreID(
+                        integration_id=str(integration.id),
+                        geostore_id=geostore_id.decode('utf8'),
+                        date_range=(lower, upper),
+                        lowest_confidence=action_config.pull_events_config.integrated_alerts_lowest_confidence,
+                        dataset=integrated_dataset_metadata
+                    )
 
-                await trigger_action(
-                    integration.id,
-                    "get_integrated_alerts_for_geostore_and_date_range",
-                    config=config
-                )
-                integrated_alerts_actions_triggered += 1
+                    await trigger_action(
+                        integration.id,
+                        "get_integrated_alerts_for_geostore_and_date_range",
+                        config=config
+                    )
+                    integrated_alerts_actions_triggered += 1
 
     # Save status for both datasets.
     if fire_dataset_metadata:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -245,13 +245,6 @@ async def action_get_integrated_alerts_for_geostore_and_date_range(
         latest_updated_on=action_config.dataset.updated_on
     )
 
-    await state_manager.set_state(
-        str(integration.id),
-        "pull_events",
-        dataset_status.dict(),
-        source_id=DATASET_GFW_INTEGRATED_ALERTS
-    )
-
     return {"dataset": DATASET_GFW_INTEGRATED_ALERTS, "response": dataset_status.dict(), "total_alerts": total_alerts}
 
 
@@ -283,6 +276,7 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
         )
 
         if fire_dataset_status:
+            logger.info(f"Saved fire dataset status: {fire_dataset_status}")
             fire_dataset_status = DatasetStatus.parse_obj(fire_dataset_status)
         else:
             fire_dataset_status = DatasetStatus(
@@ -319,6 +313,7 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
         )
 
         if integrated_dataset_status:
+            logger.info(f"Saved integrated dataset status: {integrated_dataset_status}")
             integrated_dataset_status = DatasetStatus.parse_obj(integrated_dataset_status)
         else:
             integrated_dataset_status = DatasetStatus(
@@ -382,6 +377,35 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
                 )
                 integrated_alerts_actions_triggered += 1
 
+    # Save status for both datasets.
+    if fire_dataset_metadata:
+        fire_dataset_status = DatasetStatus(
+            dataset=fire_dataset_metadata.dataset,
+            version=fire_dataset_metadata.version,
+            latest_updated_on=fire_dataset_metadata.updated_on
+        )
+
+        await state_manager.set_state(
+            str(integration.id),
+            "pull_events",
+            fire_dataset_status.dict(),
+            source_id=DATASET_NASA_VIIRS_FIRE_ALERTS
+        )
+
+    if integrated_dataset_metadata:
+        integrated_dataset_status = DatasetStatus(
+            dataset=integrated_dataset_metadata.dataset,
+            version=integrated_dataset_metadata.version,
+            latest_updated_on=integrated_dataset_metadata.updated_on
+        )
+
+        await state_manager.set_state(
+            str(integration.id),
+            "pull_events",
+            integrated_dataset_status.dict(),
+            source_id=DATASET_GFW_INTEGRATED_ALERTS
+        )
+
     return {
         "fire_alerts_actions_triggered": fire_alerts_actions_triggered,
         "integrated_alerts_actions_triggered": integrated_alerts_actions_triggered
@@ -419,13 +443,6 @@ async def action_get_nasa_viirs_fire_alerts_for_geostore_and_date_range(
         dataset=action_config.dataset.dataset,
         version=action_config.dataset.version,
         latest_updated_on=action_config.dataset.updated_on
-    )
-
-    await state_manager.set_state(
-        str(integration.id),
-        "pull_events",
-        dataset_status.dict(),
-        source_id=DATASET_NASA_VIIRS_FIRE_ALERTS
     )
 
     return {"dataset": DATASET_NASA_VIIRS_FIRE_ALERTS, "response": dataset_status.dict(), "total_alerts": total_alerts}


### PR DESCRIPTION
On some GFW connections, the connector sometimes get an error while parsing `DatasetStatus` from the state manager:

`
ValidationError: 1 validation error for DatasetStatus\n__root__\n  DatasetStatus expected dict not str (type=type_error)
`

My theory is because the `DatasetStatus` is saved on each triggered `get_fire_alerts` and `get_integrated_alerts` sub-actions, sometimes the `save_state` method fails and when the connector tries to parse it, it fails.

This PR is a small change to allow the execution save each of the datasets only once, in the `action_get_dataset_and_geostores` sub-action, after validating the `pull_events` configuration.

---

This pull request includes changes to the `app/actions/handlers.py` file to improve the logging and state management of dataset statuses. The most important changes include the addition of logging for dataset statuses and the reorganization of state-saving logic.

Logging improvements:

* Added logging for saved fire dataset status in `action_get_dataset_and_geostores` function.
* Added logging for saved integrated dataset status in `action_get_dataset_and_geostores` function.

State management improvements:

* Removed redundant state-saving logic from `action_get_integrated_alerts_for_geostore_and_date_range` function.
* Added state-saving logic for both fire and integrated dataset statuses in `action_get_dataset_and_geostores` function.
* Removed redundant state-saving logic from `action_get_nasa_viirs_fire_alerts_for_geostore_and_date_range` function.