### PR TITLE
Add --limit-concurrency for debug build.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install debugpy
 
 # Expose debugpy port too
 EXPOSE 8080 5678
-CMD ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--reload"]
+CMD ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--reload", "--limit-concurrency", "8"]
 
 FROM baseimage AS prodimage
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This PR includes a change to the debug build used for running locally, for development. It adds a concurrency limit on the service, to more closely mimic a production instance. In this case, it's eight (8) requests which is appropriate for global forest watch actions.

* [`docker/Dockerfile`](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL22-R22): Added the `--limit-concurrency` option with a value of `8` to the Uvicorn command in the development server configuration.