### PR TITLE
Catch when datasets status parsing fails and create a new one from metadata

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -2,6 +2,7 @@ import asyncio
 import httpx
 import logging
 import random
+import pydantic
 import app.settings
 
 from app.actions import utils
@@ -277,7 +278,16 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
 
         if fire_dataset_status:
             logger.info(f"Saved fire dataset status: {fire_dataset_status}")
-            fire_dataset_status = DatasetStatus.parse_obj(fire_dataset_status)
+            try:
+                fire_dataset_status = DatasetStatus.parse_obj(fire_dataset_status)
+            except pydantic.ValidationError:
+                logger.exception(
+                    f"Invalid fire dataset status: {fire_dataset_status}. Setting it from metadata..."
+                )
+                fire_dataset_status = DatasetStatus(
+                    dataset=fire_dataset_metadata.dataset,
+                    version=fire_dataset_metadata.version,
+                )
         else:
             fire_dataset_status = DatasetStatus(
                 dataset=fire_dataset_metadata.dataset,
@@ -314,7 +324,16 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
 
         if integrated_dataset_status:
             logger.info(f"Saved integrated dataset status: {integrated_dataset_status}")
-            integrated_dataset_status = DatasetStatus.parse_obj(integrated_dataset_status)
+            try:
+                integrated_dataset_status = DatasetStatus.parse_obj(integrated_dataset_status)
+            except pydantic.ValidationError:
+                logger.exception(
+                    f"Invalid integrated dataset status: {integrated_dataset_status}. Setting it from metadata..."
+                )
+                integrated_dataset_status = DatasetStatus(
+                    dataset=integrated_dataset_metadata.dataset,
+                    version=integrated_dataset_metadata.version,
+                )
         else:
             integrated_dataset_status = DatasetStatus(
                 dataset=integrated_dataset_metadata.dataset,

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -2,7 +2,6 @@ import asyncio
 import httpx
 import logging
 import random
-import pydantic
 import app.settings
 
 from app.actions import utils
@@ -25,6 +24,7 @@ from app.services.gundi import send_events_to_gundi
 from app.services.state import IntegrationStateManager
 
 from gundi_core.schemas.v2 import Integration, LogLevel
+from pydantic import ValidationError
 
 GFW_INTEGRATED_ALERTS = "gfwgladalert"
 GFW_FIRE_ALERT = "gfwfirealert"
@@ -280,7 +280,7 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
             logger.info(f"Saved fire dataset status: {fire_dataset_status}")
             try:
                 fire_dataset_status = DatasetStatus.parse_obj(fire_dataset_status)
-            except pydantic.ValidationError:
+            except ValidationError:
                 logger.exception(
                     f"Invalid fire dataset status: {fire_dataset_status}. Setting it from metadata..."
                 )
@@ -326,7 +326,7 @@ async def action_get_dataset_and_geostores(integration: Integration, action_conf
             logger.info(f"Saved integrated dataset status: {integrated_dataset_status}")
             try:
                 integrated_dataset_status = DatasetStatus.parse_obj(integrated_dataset_status)
-            except pydantic.ValidationError:
+            except ValidationError:
                 logger.exception(
                     f"Invalid integrated dataset status: {integrated_dataset_status}. Setting it from metadata..."
                 )


### PR DESCRIPTION
This pull request includes changes to the `app/actions/handlers.py` file to improve error handling when parsing dataset statuses. 

The most important changes include adding the `ValidationError` import and handling validation errors for both fire and integrated dataset statuses.

Error handling improvements:

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R27): Added import for `ValidationError` from `pydantic`.
* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R281-R290): Added a try-except block to handle `ValidationError` when parsing `fire_dataset_status` and log an appropriate error message. If validation fails, it sets the status from metadata.
* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R327-R336): Added a try-except block to handle `ValidationError` when parsing `integrated_dataset_status` and log an appropriate error message. If validation fails, it sets the status from metadata.