### PR TITLE
fix: prevent creating a new API key on 500 form GET /apikeys

### DIFF
--- a/app/actions/tests/fixtures.py
+++ b/app/actions/tests/fixtures.py
@@ -6,8 +6,8 @@ def f_api_keys_response():
     return {
         "data": [
             {
-                "created_on": "2021-09-14T08:00:00.000Z",
-                "updated_on": "2021-09-14T08:00:00.000Z",
+                "created_on": "2025-09-05T23:01:00.000Z",
+                "updated_on": "2025-09-05T23:01:00.000Z",
                 "user_id": "er_user",
                 "expires_on": "2025-09-14T08:00:00.000Z",
                 "api_key": "1234567890",
@@ -36,8 +36,8 @@ def f_auth_token_response():
 def f_create_api_key_response():
     return {
         "data": {
-            "created_on": "2021-09-14T08:00:00.000Z",
-            "updated_on": "2021-09-14T08:00:00.000Z",
+            "created_on": "2025-09-05T23:01:00.000Z",
+            "updated_on": "2025-09-05T23:01:00.000Z",
             "user_id": "er_user",
             "expires_on": "2025-09-14T08:00:00.000Z",
             "api_key": "1234567890",


### PR DESCRIPTION
This is a hotfix to prevent issues with our GFW integration account.

This pull request refactors API key management in the `gfwclient.py` client to fix an issue whereby getting a 500 error from GET /apikeys would result in creating a new API key.

**API Key Management Improvements**
* Added a new method `get_a_valid_api_key` to ensure only valid (non-expired) API keys are used, automatically creating and caching a new key if none are valid.
* Refactored `get_api_keys` and `create_api_key` to return only valid keys, removed redundant filtering logic, and updated return types for clarity.

**Reliability Enhancements**
* Added or adjusted the `factor` parameter in backoff retry decorators for `create_api_key`, `get_api_keys`, and `get_dataset_metadata` to control exponential backoff timing, improving resilience against transient errors. [[1]](diffhunk://#diff-6c1ea1c534c0d9c417e9293aed1017dd56f68d15119db1fa7c076b7400475552L377-R378) [[2]](diffhunk://#diff-6c1ea1c534c0d9c417e9293aed1017dd56f68d15119db1fa7c076b7400475552L617-R622)

**Usage Updates**
* Updated `get_alerts` and `get_dataset_metadata` to use the new `get_a_valid_api_key` method, ensuring requests always use a valid API key. [[1]](diffhunk://#diff-6c1ea1c534c0d9c417e9293aed1017dd56f68d15119db1fa7c076b7400475552L517-R519) [[2]](diffhunk://#diff-6c1ea1c534c0d9c417e9293aed1017dd56f68d15119db1fa7c076b7400475552L617-R622)