### PR TITLE
Release 20250905 hotfix

### DIFF
--- a/app/actions/tests/fixtures.py
+++ b/app/actions/tests/fixtures.py
@@ -6,8 +6,8 @@ def f_api_keys_response():
     return {
         "data": [
             {
-                "created_on": "2021-09-14T08:00:00.000Z",
-                "updated_on": "2021-09-14T08:00:00.000Z",
+                "created_on": "2025-09-05T23:01:00.000Z",
+                "updated_on": "2025-09-05T23:01:00.000Z",
                 "user_id": "er_user",
                 "expires_on": "2025-09-14T08:00:00.000Z",
                 "api_key": "1234567890",
@@ -36,8 +36,8 @@ def f_auth_token_response():
 def f_create_api_key_response():
     return {
         "data": {
-            "created_on": "2021-09-14T08:00:00.000Z",
-            "updated_on": "2021-09-14T08:00:00.000Z",
+            "created_on": "2025-09-05T23:01:00.000Z",
+            "updated_on": "2025-09-05T23:01:00.000Z",
             "user_id": "er_user",
             "expires_on": "2025-09-14T08:00:00.000Z",
             "api_key": "1234567890",


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the API key management logic in `gfwclient.py`, along with updates to related test fixtures and test cases. The changes focus on improving how valid API keys are selected, adding new API key management methods, and ensuring test reliability and speed.

**API Key Management Improvements:**

* Updated the logic in `get_a_valid_api_key` to filter out API keys created before a specific cutoff date (`magic_value_ignore_apikeys_before`) and to select the most recently created valid key instead of the first.
* Added new async methods: `delete_api_key` for deleting API keys and `validate_api_key` for validating API keys via the API.

**Test Fixture and Test Logic Updates:**

* Updated test fixtures in `fixtures.py` and `test_gfwclient.py` to use API key creation dates after the new cutoff date, ensuring consistency with the new filtering logic. [[1]](diffhunk://#diff-5f444b1a750daee93800ac665ad650e71608843e87d468c7ccfd81b239cb7e92L9-R10) [[2]](diffhunk://#diff-5f444b1a750daee93800ac665ad650e71608843e87d468c7ccfd81b239cb7e92L39-R40) [[3]](diffhunk://#diff-f23654d307be6bb8b5ff4480e494b4a6603ef613a03c8bd078ac2c94ad8ae696R7-R28) [[4]](diffhunk://#diff-f23654d307be6bb8b5ff4480e494b4a6603ef613a03c8bd078ac2c94ad8ae696L43-R56) [[5]](diffhunk://#diff-f23654d307be6bb8b5ff4480e494b4a6603ef613a03c8bd078ac2c94ad8ae696L60-R73)
* Added a `fast_backoff` pytest fixture that mocks `asyncio.sleep` to speed up backoff delays during testing, improving test performance.
* Integrated the `fast_backoff` fixture into relevant test cases to ensure faster execution of backoff logic. [[1]](diffhunk://#diff-f23654d307be6bb8b5ff4480e494b4a6603ef613a03c8bd078ac2c94ad8ae696L200-R213) [[2]](diffhunk://#diff-f23654d307be6bb8b5ff4480e494b4a6603ef613a03c8bd078ac2c94ad8ae696L244-R258)