### PR TITLE
Use 0.0/0.5/1.0 confidence scale for nominal/high/highest integrated alerts

### DIFF
--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse, parse_qs
 import httpx
 from pydantic import HttpUrl
 from datetime import datetime, timedelta, timezone
-from typing import Optional, List, Set, Tuple, Dict, Any
+from typing import ClassVar, Optional, List, Set, Tuple, Dict, Any
 
 
 logger = logging.getLogger(__name__)
@@ -220,6 +220,12 @@ class IntegratedAlert(pydantic.BaseModel):
     recorded_at: datetime = pydantic.Field(..., alias="gfw_integrated_alerts__date")
     intensity: float = pydantic.Field(0.0, alias="gfw_integrated_alerts__intensity")
 
+    CONFIDENCE_MAP: ClassVar[dict] = {
+        "nominal": 0.0,
+        "high": 0.5,
+        "highest": 1.0,
+    }
+
     @pydantic.validator(
         "recorded_at",
         pre=True,
@@ -229,12 +235,7 @@ class IntegratedAlert(pydantic.BaseModel):
 
     @pydantic.root_validator
     def compute_confidence(cls, values):
-        confidence_map = {
-            "nominal": 0.0,
-            "high": 0.5,
-            "highest": 1.0,
-        }
-        values["confidence"] = confidence_map.get(values.get("confidence_label", ""), 0.0)
+        values["confidence"] = cls.CONFIDENCE_MAP.get(values.get("confidence_label", ""), 0.0)
         return values
 
 class NasaViirsFireAlert(pydantic.BaseModel):

--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -229,9 +229,12 @@ class IntegratedAlert(pydantic.BaseModel):
 
     @pydantic.root_validator
     def compute_confidence(cls, values):
-        values["confidence"] = (
-            1.0 if values.get("confidence_label", "") in {"high", "highest"} else 0.0
-        )
+        confidence_map = {
+            "nominal": 0.0,
+            "high": 0.5,
+            "highest": 1.0,
+        }
+        values["confidence"] = confidence_map.get(values.get("confidence_label", ""), 0.0)
         return values
 
 class NasaViirsFireAlert(pydantic.BaseModel):

--- a/app/actions/tests/test_gfwclient.py
+++ b/app/actions/tests/test_gfwclient.py
@@ -292,3 +292,19 @@ async def test_fetch_integrated_alerts_backs_off_2_times_then_succeed(
     assert len([log for log in caplog.messages if "Backing off" in log]) == 5  # 1 from get_api_keys + 4 from get_alerts
     assert len(alerts) == len(f_get_alerts_response['data'])
 
+
+
+@pytest.mark.parametrize("label,expected", [
+    ("nominal", 0.0),
+    ("high", 0.5),
+    ("highest", 1.0),
+])
+def test_integrated_alert_confidence_mapping(label, expected):
+    from app.actions.gfwclient import IntegratedAlert
+    alert = IntegratedAlert(**{
+        "latitude": 0.0,
+        "longitude": 0.0,
+        "gfw_integrated_alerts__confidence": label,
+        "gfw_integrated_alerts__date": "2024-01-01",
+    })
+    assert alert.confidence == expected


### PR DESCRIPTION
## Summary
- Previously `high` and `highest` both mapped to `1.0` confidence, with only `nominal` mapping to `0.0`
- Uses a graduated scale (`0.0` / `0.5` / `1.0`) that better reflects the three distinct confidence levels from the GFW dataset

## Test plan
- [ ] Verify integrated alerts with `nominal` confidence arrive in ER with `confidence=0.0`
- [ ] Verify integrated alerts with `high` confidence arrive in ER with `confidence=0.5`
- [ ] Verify integrated alerts with `highest` confidence arrive in ER with `confidence=1.0`

## Screenshots
high confidence
<img width="707" height="370" alt="image" src="https://github.com/user-attachments/assets/4efa5022-b5ad-4798-979e-adf8323d0f10" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)