### PR TITLE
fix: parse AOI IDs from globalnaturewatch.org share link redirects

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install pip
         run: python -m ensurepip --upgrade
       - name: Install pip tools
-        # pip-tools 7.6.0 imports typing_extensions but omits it from its dependencies
+        # some pip-tools releases (e.g. 7.6.0) import typing_extensions without declaring it as a dependency
         run: pip install pip-tools typing_extensions
       - name: Install compile dependencies
         run: pip-compile --output-file=requirements.txt requirements-base.in requirements-dev.in requirements.in

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Install pip
         run: python -m ensurepip --upgrade
       - name: Install pip tools
-        run: pip install pip-tools
+        # pip-tools 7.6.0 imports typing_extensions but omits it from its dependencies
+        run: pip install pip-tools typing_extensions
       - name: Install compile dependencies
         run: pip-compile --output-file=requirements.txt requirements-base.in requirements-dev.in requirements.in
       - name: Install dependencies

--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -855,7 +855,7 @@ class DataAPI:
             return matches[1]
 
         logger.error("Unable to parse AOI from URL: %s (resolved to: %s)", url, head.url)
-        raise GFWClientException(f"Unable to parse AOI from URL: '{url}'")
+        raise GFWClientException(f"Unable to parse AOI from URL: '{url}' (resolved to: '{head.url}')")
 
 
     @backoff.on_exception(backoff.constant, httpx.HTTPError, max_tries=3, interval=10)

--- a/app/actions/gfwclient.py
+++ b/app/actions/gfwclient.py
@@ -844,18 +844,18 @@ class DataAPI:
         Extracts the AOI ID from a GFW share link URL.
         """
 
-        URL_PATTERN = ".*globalforestwatch.org.*aoi/([^/]+).*"
+        URL_PATTERN = r".*(?:globalforestwatch|globalnaturewatch)\.org.*aoi/([^/]+).*"
         if matches := re.match(URL_PATTERN, url):
             return matches[1]
-        
+
         async with httpx.AsyncClient(timeout=DEFAULT_REQUEST_TIMEOUT) as client:
             head = await client.head(url, follow_redirects=True)
 
-        try:
-            matches = re.match(URL_PATTERN, str(head.url))
+        if matches := re.match(URL_PATTERN, str(head.url)):
             return matches[1]
-        except IndexError:
-            logger.error("Unable to parse AOI from globalforestwatch URL: %s", url)
+
+        logger.error("Unable to parse AOI from URL: %s (resolved to: %s)", url, head.url)
+        raise GFWClientException(f"Unable to parse AOI from URL: '{url}'")
 
 
     @backoff.on_exception(backoff.constant, httpx.HTTPError, max_tries=3, interval=10)

--- a/app/actions/tests/test_gfwclient.py
+++ b/app/actions/tests/test_gfwclient.py
@@ -6,7 +6,7 @@ import httpx
 import respx
 from unittest.mock import patch
 
-from app.actions.gfwclient import DataAPI, DataAPIKeysResponse
+from app.actions.gfwclient import DataAPI, DataAPIKeysResponse, GFWClientException
 
 @pytest.fixture
 def fast_backoff():
@@ -292,6 +292,41 @@ async def test_fetch_integrated_alerts_backs_off_2_times_then_succeed(
     assert len([log for log in caplog.messages if "Backing off" in log]) == 5  # 1 from get_api_keys + 4 from get_alerts
     assert len(alerts) == len(f_get_alerts_response['data'])
 
+
+
+@pytest.mark.asyncio
+async def test_aoi_from_url_parses_globalforestwatch_url_directly():
+    client = DataAPI(username="test@example.com", password="test_password")
+    aoi_id = await client.aoi_from_url(
+        "https://www.globalforestwatch.org/map/aoi/64020c320ec654001bada78e/?mainMap=eyJzaG93QW5hbHlzaXMiOnRydWV9"
+    )
+    assert aoi_id == "64020c320ec654001bada78e"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_aoi_from_url_follows_redirect_to_globalnaturewatch():
+    short_url = "https://gfw.global/3Jhekkw"
+    final_url = "https://globalnaturewatch.org/map/aoi/64020c320ec654001bada78e/?mainMap=eyJzaG93QW5hbHlzaXMiOnRydWV9"
+    respx.head(short_url).respond(status_code=302, headers={"Location": final_url})
+    respx.head(final_url).respond(status_code=200)
+
+    client = DataAPI(username="test@example.com", password="test_password")
+    aoi_id = await client.aoi_from_url(short_url)
+    assert aoi_id == "64020c320ec654001bada78e"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_aoi_from_url_raises_on_unparseable_url():
+    short_url = "https://gfw.global/3Jhekkw"
+    final_url = "https://globalnaturewatch.org/some/other/page"
+    respx.head(short_url).respond(status_code=302, headers={"Location": final_url})
+    respx.head(final_url).respond(status_code=200)
+
+    client = DataAPI(username="test@example.com", password="test_password")
+    with pytest.raises(GFWClientException):
+        await client.aoi_from_url(short_url)
 
 
 @pytest.mark.parametrize("label,expected", [

--- a/app/actions/tests/test_gfwclient.py
+++ b/app/actions/tests/test_gfwclient.py
@@ -325,8 +325,10 @@ async def test_aoi_from_url_raises_on_unparseable_url():
     respx.head(final_url).respond(status_code=200)
 
     client = DataAPI(username="test@example.com", password="test_password")
-    with pytest.raises(GFWClientException):
+    with pytest.raises(GFWClientException) as excinfo:
         await client.aoi_from_url(short_url)
+    assert short_url in str(excinfo.value)
+    assert final_url in str(excinfo.value)
 
 
 @pytest.mark.parametrize("label,expected", [


### PR DESCRIPTION
GFW share links (`gfw.global`) now redirect to `globalnaturewatch.org` instead of `globalforestwatch.org`, so `aoi_from_url` could no longer parse the AOI ID from the resolved URL and every 10-minute `pull_events` run failed with `Failed to fetch AOI data ... 'NoneType' object is not subscriptable` for any integration without cached AOI data — 64 integrations in production logs from Aug 1, with no alerts being pulled for them.

The URL pattern now accepts both domains, and an unparseable URL raises `GFWClientException` naming the original and resolved URLs instead of the accidental `TypeError` (the previous `except IndexError` could never catch it, and the fallback silently returned `None`).

Validation: new tests cover direct `globalforestwatch.org` URLs, a short link redirecting to `globalnaturewatch.org`, and the unparseable-URL error path; the redirect test reproduced the exact production failure before the fix. A live run against a failing link from the logs (`https://gfw.global/3Jhekkw`) resolves the redirect chain and extracts AOI ID `64020c320ec654001bada78e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
